### PR TITLE
Add 3-argument hypot

### DIFF
--- a/include/jakalib/math.h
+++ b/include/jakalib/math.h
@@ -1,0 +1,43 @@
+#ifndef JAKALIB_MATH_H
+#define JAKALIB_MATH_H
+
+#include <algorithm>
+#include <cmath>
+
+namespace jakalib {
+namespace detail {
+template <typename T>
+T sqr(T x) {
+  return x * x;
+}
+
+template <typename T>
+T hypot3(T x, T y, T z) {
+  x = std::abs(x);
+  y = std::abs(y);
+  z = std::abs(z);
+
+  T m = std::max(std::max(x, y), z);
+  if (m == T(0)) {
+    return T(0);
+  }
+  T m_inv = T(1.0) / m;
+  return m * std::sqrt(sqr(x * m_inv) + sqr(y * m_inv) + sqr(z * m_inv));
+}
+}  // namespace detail
+
+// Computes the square root of the sum of the squares of x, y and z, without
+// undue overflow or underflow at intermediate stages of the computation.
+inline float hypot(float x, float y, float z) {
+  return detail::hypot3<float>(x, y, z);
+}
+
+inline double hypot(double x, double y, double z) {
+  return detail::hypot3<double>(x, y, z);
+}
+
+inline long double hypot(long double x, long double y, long double z) {
+  return detail::hypot3<long double>(x, y, z);
+}
+}  // namespace jakalib
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,3 +27,7 @@ add_test(container_size_test container_size_test)
 add_executable(inclusion_test inclusion_test.cpp)
 target_link_libraries(inclusion_test jakalib)
 add_test(inclusion_test inclusion_test)
+
+add_executable(math_test math_test.cpp)
+target_link_libraries(math_test jakalib)
+add_test(math_test math_test)

--- a/test/math_test.cpp
+++ b/test/math_test.cpp
@@ -1,0 +1,34 @@
+#include "jakalib/math.h"
+
+using namespace jakalib;
+
+#define assert_close(actual, expected)                                         \
+  do {                                                                         \
+    auto _0 = actual;                                                          \
+    auto _1 = expected;                                                        \
+    assert(std::abs(_0 - _1) < 1e-10);                                         \
+  } while (false)
+
+void hypotTest() {
+  assert_close(hypot(0.0, 0.0, 0.0), 0.0);
+  assert_close(hypot(3.0, 4.0, 0.0), 5.0);
+  assert_close(hypot(0.0, -3.0, 4.0), 5.0);
+  assert_close(hypot(-3.0, 0.0, 4.0), 5.0);
+  assert_close(hypot(2.0, -7.0, 26.0), 27.0);
+  assert_close(hypot(-0.2, 0.7, -2.6), 2.7);
+
+  long double x =
+      std::numeric_limits<long double>::max() / 2.12345678901234567890l;
+  assert_close(hypot(x, 0.0l, 0.0l), x);
+  assert_close(hypot(x, x, 0.0l), x * std::sqrt(2.0l));
+  assert_close(hypot(x, x, x), x * std::sqrt(3.0l));
+  assert_close(hypot(-x, x, x), x * std::sqrt(3.0l));
+  assert_close(hypot(-x, -x, x), x * std::sqrt(3.0l));
+  assert_close(hypot(-x, -x, -x), x * std::sqrt(3.0l));
+  assert_close(hypot(1.0 / x, 0.0l, 0.0l), 1.0l / x);
+}
+
+int main() {
+  hypotTest();
+  return 0;
+}


### PR DESCRIPTION
This PR implements the 3-argument hypot function introduced in C++17 (https://en.cppreference.com/w/cpp/numeric/math/hypot)